### PR TITLE
Added field converter feature

### DIFF
--- a/lib/rfm/metadata/field.rb
+++ b/lib/rfm/metadata/field.rb
@@ -63,12 +63,13 @@ module Rfm
       
       # Initializes a field object. You'll never need to do this. Instead, get your Field objects from
       # ResultSet::fields
-      def initialize(field)
+      def initialize(field, converter = nil)
         @name        = field.name #['name']
         @result      = field.result #['result']
         @type        = field.type #['type']
         @max_repeats = field.max_repeats #['max-repeats']
         @global      = field.global #['global']
+        @converter   = converter
       end
     
       # Coerces the text value from an +fmresultset+ document into proper Ruby types based on the 
@@ -76,7 +77,7 @@ module Rfm
       # access field data through the Record object.
       def coerce(value, resultset)
         return nil if (value.nil? or value.empty?)
-        case self.result.downcase
+        value = case self.result.downcase
         when "text"      then value
         when "number"    then BigDecimal.new(value)
         when "date"      then Date.strptime(value, resultset.date_format)
@@ -85,7 +86,7 @@ module Rfm
         when "container" then URI.parse("#{resultset.server.scheme}://#{resultset.server.host_name}:#{resultset.server.port}#{value}")
         else nil
         end
-        
+        @converter.nil? ? value : @converter.call(value)
       end
       
     end # Field

--- a/lib/rfm/resultset.rb
+++ b/lib/rfm/resultset.rb
@@ -103,9 +103,11 @@ module Rfm
       @foundset_count   = doc.foundset_count
       @total_count      = doc.total_count
       @table            = doc.table
-            
-      (layout.table = @table) if layout and layout.table_no_load.blank?
       
+      @converter_fields = desensitize_converter_fields      
+      
+      (layout.table = @table) if layout and layout.table_no_load.blank?
+
       parse_fields(doc)
       
       # This will always load portal meta, even if :include_portals was not specified.
@@ -155,7 +157,7 @@ module Rfm
       	return if doc.fields.blank?
 
         doc.fields.each do |field|
-          @field_meta[field.name] = Rfm::Metadata::Field.new(field)
+          @field_meta[field.name] = Rfm::Metadata::Field.new(field, @converter_fields[field.name])
         end
         (layout.field_names = field_names) if layout and layout.field_names_no_load.blank?
       end
@@ -175,7 +177,13 @@ module Rfm
         end
         (layout.portal_meta = @portal_meta) if layout and layout.portal_meta_no_load.blank?
       end
-    
+
+      def desensitize_converter_fields
+        rfm_hash = Rfm::CaseInsensitiveHash.new
+        (state[:converters] || {} ).each_pair { |k,v| rfm_hash[k] = v }
+        rfm_hash
+      end
+      
 			#   def convert_date_time_format(fm_format)
 			#     fm_format.gsub!('MM', '%m')
 			#     fm_format.gsub!('dd', '%d')

--- a/lib/rfm/utilities/config.rb
+++ b/lib/rfm/utilities/config.rb
@@ -11,6 +11,7 @@ module Rfm
 			password
 			database
 			layout
+			converters
 			ignore_bad_data
 			ssl
 			root_cert


### PR DESCRIPTION
Added a converters configuration option allowing custom conversion of values in resultsets. A hash of field/lambda pairs is assigned to the converters configuration key to enable the feature.

As an example, you could specify that the 'logincount' field in this User model should be returned as an integer:

``` ruby
class User < Rfm::Base
  config :layout => 'my_user_layout'
  config :converters => {
    'logincount' => lambda { |f| f.to_i }
  }
end
```
