### PR TITLE
fix specs

### DIFF
--- a/spec/active_model_lint.rb
+++ b/spec/active_model_lint.rb
@@ -21,9 +21,9 @@ shared_examples_for "ActiveModel" do
 
   attr_accessor :assertions
 
-  def initialize
+  def initialize(args)
     self.assertions = 0
-    super
+    super(args)
   end
 
   ActiveModel::Lint::Tests.public_instance_methods.map{|m| m.to_s}.grep(/^test/).each do |m|


### PR DESCRIPTION
I was running into this:

  1) Rfm::Base TestModel it should behave like ActiveModel test to key
     Got 0 failures and 2 other errors:
     Shared Example Group: "ActiveModel" called from ./spec/rfm/base_spec.rb:10

     1.1) Failure/Error: def initialize
          ArgumentError:
            wrong number of arguments (1 for 0)
          # ./spec/active_model_lint.rb:24:in `initialize'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:520:in `new'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:520:in `run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:522:in `block in run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:522:in `map'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:522:in `run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:522:in `block in run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:522:in `map'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:522:in `run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:115:in `block (3 levels) in run_specs'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:115:in `map'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:115:in `block (2 levels) in run_specs'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1627:in `with_suite_hooks'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:114:in `block in run_specs'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/reporter.rb:77:in `report'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:113:in `run_specs'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:89:in `run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
          # /Users/jon/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'